### PR TITLE
help prevent orphaned processes when sigint supervisord.

### DIFF
--- a/snakes/go/spring-league-2022/logic.go
+++ b/snakes/go/spring-league-2022/logic.go
@@ -19,9 +19,9 @@ func info() BattlesnakeInfoResponse {
 	log.Println("INFO")
 	return BattlesnakeInfoResponse{
 		APIVersion: "1",
-		Author:     "ES",      // TODO: Your Battlesnake username
+		Author:     "ES Team", // TODO: Your Battlesnake username
 		Color:      "#888888", // TODO: Personalize
-		Head:       "default", // TODO: Personalize
+		Head:       "gamer",   // TODO: Personalize
 		Tail:       "default", // TODO: Personalize
 	}
 }

--- a/snakes/go/spring-league-2022/main.go
+++ b/snakes/go/spring-league-2022/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 )
 
 type GameState struct {
@@ -148,6 +149,19 @@ func HandleEnd(w http.ResponseWriter, r *http.Request) {
 // Main Entrypoint
 
 func main() {
+
+	// Listen for sigint and exit the program
+	// Not needed for supervisord but makes a cleaner close when running locally.
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	go func() {
+		for sig := range c {
+			// exit the program
+			log.Printf("Received %s, Battlesnake Server exiting...\n", sig)
+			os.Exit(0)
+		}
+	}()
+
 	port := os.Getenv("PORT")
 	if len(port) == 0 {
 		port = "8080"

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -77,3 +77,4 @@ stdout_logfile_maxbytes=0
 stderr_logfile_maxbytes=0
 stdout_logfile=/dev/stdout
 stderr_logfile=/dev/stderr
+stopasgroup=true


### PR DESCRIPTION
This adds the `stopasgroup=true` setting to the Go snake supervisord config so that we don't end up with orphaned processes. 

[stopasgroup](http://supervisord.org/configuration.html?highlight=stopasgroup)

> If true, the flag causes supervisor to send the stop signal to the whole process group and implies killasgroup is true. This is useful for programs, such as Flask in debug mode, that do not propagate stop signals to their children, leaving them orphaned.

Example output when `^C` locally:

```
# go run main.go logic.go helpers.go 
2022/02/02 00:27:15 Starting Battlesnake Server at http://0.0.0.0:8080...


^C2022/02/02 00:27:18 Received interrupt, Battlesnake Server exiting...
```

I also tweaked the customization settings here a bit just to see if this setting prevents us from manually needing to restart the container on deploy. 