### PR TITLE
Eat food and Smarter hazard choice

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,29 @@
+name: Go
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "*.go"
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "*.go"
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...

--- a/snakes/go/spring-league-2022/logic_test.go
+++ b/snakes/go/spring-league-2022/logic_test.go
@@ -19,7 +19,7 @@ func TestNeckAvoidance(t *testing.T) {
 	}
 
 	// Act 1,000x (this isn't a great way to test, but it's okay for starting out)
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 100; i++ {
 		nextMove := move(state)
 		// Assert never move left
 		if nextMove.Move == "left" {
@@ -44,11 +44,66 @@ func TestBodyAvoidance(t *testing.T) {
 	}
 
 	// Act 1,000x (this isn't a great way to test, but it's okay for starting out)
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 100; i++ {
 		nextMove := move(state)
 		// Assert never move right
 		if nextMove.Move == "right" {
 			t.Errorf("snake moved onto its own body, %s", nextMove.Move)
+		}
+	}
+}
+
+// Test that we go towards nearest food.
+func TestFoodEating(t *testing.T) {
+	// Arrange
+	me := Battlesnake{
+		// Length 4
+		Head: Coord{X: 2, Y: 1},
+		Body: []Coord{{X: 2, Y: 1}, {X: 2, Y: 0}, {X: 3, Y: 0}, {X: 4, Y: 0}},
+	}
+	state := GameState{
+		Board: Board{
+			Snakes: []Battlesnake{me},
+			Food:   []Coord{{X: 4, Y: 3}, {X: 4, Y: 1}, {X: 3, Y: 3}, {X: 1, Y: 1}},
+		},
+		You: me,
+	}
+	// Act 1,000x (this isn't a great way to test, but it's okay for starting out)
+	for i := 0; i < 5; i++ {
+		nextMove := move(state)
+		// Assert never move right
+		if nextMove.Move != "left" {
+			t.Errorf("snake didn't move towards closest food, %s", nextMove.Move)
+		}
+	}
+}
+
+// Test that we go towards second closest food.
+func TestFoodEating2(t *testing.T) {
+	// Arrange
+	me := Battlesnake{
+		// Length 4
+		Head: Coord{X: 2, Y: 1},
+		Body: []Coord{{X: 2, Y: 1}, {X: 2, Y: 0}, {X: 3, Y: 0}, {X: 4, Y: 0}},
+	}
+	other := Battlesnake{
+		// Length 4
+		Head: Coord{X: 1, Y: 1},
+		Body: []Coord{{X: 1, Y: 2}, {X: 1, Y: 3}, {X: 1, Y: 4}, {X: 1, Y: 5}},
+	}
+	state := GameState{
+		Board: Board{
+			Snakes: []Battlesnake{me, other},
+			Food:   []Coord{{X: 4, Y: 3}, {X: 4, Y: 1}, {X: 3, Y: 3}, {X: 0, Y: 1}},
+		},
+		You: me,
+	}
+	// Act 1,000x (this isn't a great way to test, but it's okay for starting out)
+	for i := 0; i < 5; i++ {
+		nextMove := move(state)
+		// Assert never move right
+		if nextMove.Move == "left" {
+			t.Errorf("snake didn't move towards second closest food, %s", nextMove.Move)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #102 and #103 

Updated hazard avoidance logic so that it will move into a hazard cell if that is the only move available.

Added in some food searching logic. I might have over complicated this but it works. We take this list of of available food on the board and then sort it based on distance from head. Then loop through the sorted list and figure out if we can move there. If we cant then we check to see if we can move the second closest and so on. 