### PR TITLE
I noticed that we are still walking our own tail early

### DIFF
--- a/snakes/go/pathy-snake/pathing.go
+++ b/snakes/go/pathy-snake/pathing.go
@@ -113,7 +113,7 @@ func addSnakesToGrid(state GameState, grid *Grid) {
 	grid.Get(state.You.Head.X, state.You.Head.Y).Walkable = true
 
 	// If we did not eat food on the previous turn, we can make our tail walkable.
-	if state.You.Length > 2 {
+	if state.Turn > 3 {
 		if !checkIfAteFood(state) {
 			// Make sure our tail is walkable.
 			grid.Get(state.You.Body[len(state.You.Body)-1].X, state.You.Body[len(state.You.Body)-1].Y).Walkable = true


### PR DESCRIPTION
Looks like snakes start as a certain length but confined to a single square. 

Example game: https://play.battlesnake.com/g/bfdf1a16-8713-4b11-93b5-13faa751eefc/

and Battlesnake docs say:

> At the beginning of each game every Battlesnake will be the same size and occupy a single square. This is naturally very uncomfortable for them, and as they make their first few moves they will stretch out to their full length.

Hoping that by turn 3 we are unfurled enough so we stop going back on ourselves. 

