### PR TITLE
Don't dive bomb larger snakes when eating

### DIFF
--- a/snakes/go/pathy-snake/helpers.go
+++ b/snakes/go/pathy-snake/helpers.go
@@ -53,3 +53,34 @@ func onEdge(x int, y int, width int, height int) bool {
 	}
 	return false
 }
+
+// This function takes and x,y coord and tells us if there is a snake next to it larger than us. 
+func isNextToLarger(x int, y int, state GameState) bool {
+	// check if there is a snake next to us that is larger than us.
+	for _, snake := range state.Board.Snakes {
+		// if the snake is us, skip it.
+		if snake.ID == state.You.ID {
+			continue
+		}
+		// if the snake is smaller than us, skip it.
+		if snake.Length < state.You.Length {
+			continue
+		}
+		// Check if the snake is to the left, right, above, or below us.
+		if snake.Head.X == x-1 && snake.Head.Y == y {
+			return true
+		}
+		if snake.Head.X == x+1 && snake.Head.Y == y {
+			return true
+		}
+		if snake.Head.X == x && snake.Head.Y == y-1 {
+			return true
+		}
+		if snake.Head.X == x && snake.Head.Y == y+1 {
+			return true
+		}
+	}
+	return false
+}
+
+

--- a/snakes/go/pathy-snake/logic_test.go
+++ b/snakes/go/pathy-snake/logic_test.go
@@ -115,6 +115,41 @@ func TestFoodEating2(t *testing.T) {
 	}
 }
 
+// Test that we go towards the closest food not next to large snake.
+func TestFoodEating3(t *testing.T) {
+	// Arrange
+	me := Battlesnake{
+		Head:   Coord{X: 5, Y: 5},
+		Body:   []Coord{{X: 5, Y: 5}, {X: 5, Y: 4}, {X: 5, Y: 3}},
+		Health: 20,
+		Length: 3,
+		ID:    "me",
+	}
+	other := Battlesnake{
+		Head: Coord{X: 8, Y: 5},
+		Body: []Coord{{X: 8, Y: 5}, {X: 8, Y: 4}, {X: 8, Y: 3}, {X: 8, Y: 2}},
+		Length: 4,
+		ID:    "other",
+	}
+	state := GameState{
+		Board: Board{
+			Snakes: []Battlesnake{me, other},
+			Food:   []Coord{{X: 7, Y: 5}, {X: 5, Y: 9}},
+			Height: 11,
+			Width:  11,
+		},
+		You: me,
+	}
+	// Act 1000x (this isn't a great way to test, but it's okay for starting out)
+	for i := 0; i < 1000; i++ {
+		nextMove := move(state)
+		// Assert never move left
+		if nextMove.Move != "up" {
+			t.Errorf("snake moved to a food next to bigger snake, %s", nextMove.Move)
+		}
+	}
+}
+		
 // Test that we do not wrap around into our own body.
 func TestBodyWrap1(t *testing.T) {
 	// Arrange

--- a/snakes/go/pathy-snake/pathing.go
+++ b/snakes/go/pathy-snake/pathing.go
@@ -227,6 +227,10 @@ func getPath(state GameState, grid *Grid) *Path {
 			var closestFoodCell *Cell
 			var closestDistance int
 			for _, food := range state.Board.Food {
+				// Skip the food if it is isNextToLarger.
+				if isNextToLarger(food.X, food.Y, state) {
+					continue
+				}
 				// Get the manhattan distance between the head and the food.
 				distance := abs(food.X-state.You.Head.X) + abs(food.Y-state.You.Head.Y)
 				// If the distance is less than the closest distance, then set the food to be the closest food.


### PR DESCRIPTION
After the Health bump we were sometimes dive bombing into food cells that were way to close to larger snakes which usually resulted in getting eat ourselves. This should help prevent us from targeting a piece of food if it is next to a larger snake. 

https://play.battlesnake.com/g/aef8f8fb-ed02-483c-aa4a-793aabc8b562/
https://play.battlesnake.com/g/14b3f49c-36b8-43c6-98c0-71ad77604f31/