### PR TITLE
Tail Walking Order

### DIFF
--- a/snakes/go/pathy-snake/logic_test.go
+++ b/snakes/go/pathy-snake/logic_test.go
@@ -699,3 +699,74 @@ for i := 0; i < 1; i++ {
 }
 }
 
+// Test that we don't set a tail next to a head as walkable.
+// Multi turn test to make sure we are setting snake tails as walkable correctly.
+func TestTailWalkable3(t *testing.T) {
+	for i := 0; i < 1; i++ {	
+		// Arrange
+		me := Battlesnake{
+			Head: Coord{X: 4, Y: 4},
+			Body: []Coord{{X: 4, Y: 4}, {X: 4, Y: 5}, {X: 5, Y: 5}},
+			Health: 100,
+			ID: "me",
+		}
+		other := Battlesnake{
+			Head: Coord{X: 5, Y: 3},
+			Body: []Coord{{X: 5, Y: 3},{X: 6, Y: 3}, {X: 6, Y: 4}, {X: 7, Y: 4}, {X: 7, Y: 3}, {X: 7, Y: 2}, {X: 6, Y: 2}, {X: 5, Y: 2}, {X: 4, Y: 2}, {X: 4, Y: 3}},
+			Health: 100,
+			ID: "other",
+		}
+		state := GameState{
+			Board: Board{
+				Snakes: []Battlesnake{me, other},
+				Height: 11,
+				Width:  11,
+				Food:   []Coord{{X: 3, Y: 10}},
+			},
+			Turn: 9999999,
+			You: me,
+		}
+		// Act 1000x (this isn't a great way to test, but it's okay for starting out)
+		for i := 0; i < 1000; i++ {
+			nextMove := move(state)
+			// Assert never move up
+			if nextMove.Move == "down" {
+				t.Errorf("Tail incorrectly set as walkable, %s", nextMove.Move)
+			}
+		}
+	}
+	for i := 0; i < 1; i++ {
+		// Arrange
+		me := Battlesnake{
+			Head: Coord{X: 4, Y: 4},
+			Body: []Coord{{X: 4, Y: 4}, {X: 4, Y: 5}, {X: 5, Y: 5}},
+			Health: 90,
+			ID: "me",
+		}
+		other := Battlesnake{
+			Head: Coord{X: 5, Y: 3},
+			Body: []Coord{{X: 5, Y: 3},{X: 6, Y: 3}, {X: 6, Y: 4}, {X: 7, Y: 4}, {X: 7, Y: 3}, {X: 7, Y: 2}, {X: 6, Y: 2}, {X: 5, Y: 2}, {X: 4, Y: 2}, {X: 4, Y: 3}},
+			Health: 90,
+			ID: "other",
+		}
+		state := GameState{
+			Board: Board{
+				Snakes: []Battlesnake{me, other},
+				Height: 11,
+				Width:  11,
+				Food:   []Coord{{X: 5, Y: 4}},
+			},
+			Turn: 9999999,
+			You: me,
+		}
+		// Act 1000x (this isn't a great way to test, but it's okay for starting out)
+		for i := 0; i < 1000; i++ {
+			nextMove := move(state)
+			// Assert never move up
+			if nextMove.Move == "down" {
+				t.Errorf("Tail incorrectly set as walkable, %s", nextMove.Move)
+			}
+		}
+	}
+}
+

--- a/snakes/go/pathy-snake/pathing.go
+++ b/snakes/go/pathy-snake/pathing.go
@@ -39,6 +39,25 @@ func addSnakesToGrid(state GameState, grid *Grid) {
 			grid.Get(bodyPart.X, bodyPart.Y).Walkable = false
 		}
 	}
+
+	// Clear any map that might exist between games.
+	// Note: 9999999 is used for testing purposes.
+	if state.Turn <= 3 || state.Turn == 9999999 {
+		snakeHealths = make(map[string]int)
+		updateSnakeHealth(state)
+	}
+	// If a snake did not eat food on the previous turn, we can make their tail walkable.
+	if state.Turn > 3 {
+		for _, otherSnake := range state.Board.Snakes {
+			if !didSnakeEatFood(otherSnake, state) {
+				// Make sure their tail is walkable.
+				grid.Get(otherSnake.Body[len(otherSnake.Body)-1].X, otherSnake.Body[len(otherSnake.Body)-1].Y).Walkable = true
+			}
+		}
+	// Update each snakes health with the health from this turn. 
+	 updateSnakeHealth(state)
+	}
+
 	// Iterrate over all the the other snakes heads.
 	for _, otherSnake := range state.Board.Snakes {
 		if otherSnake.ID != state.You.ID {
@@ -112,23 +131,6 @@ func addSnakesToGrid(state GameState, grid *Grid) {
 	// would not find a path if our head was not walkable.
 	grid.Get(state.You.Head.X, state.You.Head.Y).Walkable = true
 
-	// Clear any map that might exist between games.
-	// Note: 9999999 is used for testing purposes.
-	if state.Turn <= 3 || state.Turn == 9999999 {
-		snakeHealths = make(map[string]int)
-		updateSnakeHealth(state)
-	}
-	// If a snake did not eat food on the previous turn, we can make their tail walkable.
-	if state.Turn > 3 {
-		for _, otherSnake := range state.Board.Snakes {
-			if !didSnakeEatFood(otherSnake, state) {
-				// Make sure their tail is walkable.
-				grid.Get(otherSnake.Body[len(otherSnake.Body)-1].X, otherSnake.Body[len(otherSnake.Body)-1].Y).Walkable = true
-			}
-		}
-	// Update each snakes health with the health from this turn. 
-	 updateSnakeHealth(state)
-	}
 }
 
 // Add food to the grid as walkable but with lower cost.


### PR DESCRIPTION
I noticed in this game: https://play.battlesnake.com/g/ef883849-66b7-4822-8c07-7f366f78d93f/ on the very last turn...

<img width="486" alt="Screen Shot 2022-02-25 at 9 02 39 PM" src="https://user-images.githubusercontent.com/17680929/155829894-f0d92f42-de50-49cb-b682-9e9dcb265a70.png">

We set the opposing snake tail as walkable even though it was next to a larger snakes head because the tail walking logic came after the large head logic and so we overrode what was set earlier. 

This PR just moves the tail walking logic up a bit so it happens before we set cells next to large snake heads as un-walkable. 

