### PR TITLE
Fix tail bug and tests

### DIFF
--- a/snakes/go/pathy-snake/logic_test.go
+++ b/snakes/go/pathy-snake/logic_test.go
@@ -567,200 +567,188 @@ func TestCornerTrap4(t *testing.T) {
 
 // Test that we are setting our own tail as walkable.
 func TestTailWalkable1(t *testing.T) {
-	for i := 0; i < 1; i++ {
-		// Arrange
-		me := Battlesnake{
-			Head: Coord{X: 4, Y: 4},
-			Body: []Coord{{X: 4, Y: 4}, {X: 4, Y: 5}, {X: 3, Y: 5}, {X: 3, Y: 4}, {X: 3, Y: 3}, {X: 4, Y: 3}},
-			Health: 100,
-			ID: "me",
-		}
-		state := GameState{
-			Board: Board{
-				Snakes: []Battlesnake{me},
-				Height: 11,
-				Width:  11,
-				Food:   []Coord{{X: 3, Y: 10}},
-			},
-			Turn: 0,
-			You: me,
-		}
-		// Act 1000x (this isn't a great way to test, but it's okay for starting out)
-		for i := 0; i < 1000; i++ {
+	for i := 0; i < 1000; i++ {
+		for i := 0; i < 1; i++ {
+			// Arrange
+			me := Battlesnake{
+				Head: Coord{X: 4, Y: 4},
+				Body: []Coord{{X: 4, Y: 4}, {X: 4, Y: 5}, {X: 3, Y: 5}, {X: 3, Y: 4}, {X: 3, Y: 3}, {X: 4, Y: 3}},
+				Health: 100,
+				ID: "me",
+			}
+			state := GameState{
+				Board: Board{
+					Snakes: []Battlesnake{me},
+					Height: 11,
+					Width:  11,
+					Food:   []Coord{{X: 3, Y: 10}},
+				},
+				Turn: 0,
+				You: me,
+			}
 			nextMove := move(state)
 			// Assert never move up
 			if nextMove.Move == "down" {
 				t.Errorf("Walked on tail to early, %s", nextMove.Move)
 			}
 		}
-	}
-	for i := 0; i < 1; i++ {
-		// Arrange
-		me := Battlesnake{
-			Head: Coord{X: 4, Y: 4},
-			Body: []Coord{{X: 4, Y: 4}, {X: 4, Y: 5}, {X: 3, Y: 5}, {X: 3, Y: 4}, {X: 3, Y: 3}, {X: 4, Y: 3}},
-			Health: 20,
-			ID: "me",
-		}
-		other := Battlesnake{
-			Head: Coord{X: 5, Y: 4},
-			Body: []Coord{{X: 5, Y: 4}, {X: 5, Y: 3}, {X: 5, Y: 2}},
-			ID: "other",
-		}
-		state := GameState{
-			Board: Board{
-				Snakes: []Battlesnake{me, other},
-				Height: 11,
-				Width:  11,
-				Food:   []Coord{{X: 3, Y: 10}},
-			},
-			Turn: 9999999,
-			You: me,
-		}
-		// Act 1000x (this isn't a great way to test, but it's okay for starting out)
-		for i := 0; i < 1000; i++ {
+		for i := 0; i < 1; i++ {
+			// Arrange
+			me := Battlesnake{
+				Head: Coord{X: 4, Y: 4},
+				Body: []Coord{{X: 4, Y: 4}, {X: 4, Y: 5}, {X: 3, Y: 5}, {X: 3, Y: 4}, {X: 3, Y: 3}, {X: 4, Y: 3}},
+				Health: 20,
+				ID: "me",
+			}
+			other := Battlesnake{
+				Head: Coord{X: 5, Y: 4},
+				Body: []Coord{{X: 5, Y: 4}, {X: 5, Y: 3}, {X: 5, Y: 2}},
+				ID: "other",
+			}
+			state := GameState{
+				Board: Board{
+					Snakes: []Battlesnake{me, other},
+					Height: 11,
+					Width:  11,
+					Food:   []Coord{{X: 3, Y: 10}},
+				},
+				Turn: 9999999,
+				You: me,
+			}
 			nextMove := move(state)
 			// Assert never move up
 			if nextMove.Move != "down" {
 				t.Errorf("Tail is not getting set as walkable, %s", nextMove.Move)
-			}
-		}	
+			}	
+		}
 	}
 }
 
 // Test that we are setting a neighboring snake tail as walkable.
 // Multi turn test to make sure we are setting snake tails as walkable correctly.
 func TestTailWalkable2(t *testing.T) {
-for i := 0; i < 1; i++ {	
-	// Arrange
-	me := Battlesnake{
-		Head: Coord{X: 4, Y: 4},
-		Body: []Coord{{X: 4, Y: 4}, {X: 4, Y: 5}, {X: 3, Y: 5}, {X: 3, Y: 4}, {X: 3, Y: 3}, {X: 4, Y: 3}, {X: 5, Y: 3}},
-		Health: 100,
-		ID: "me",
-	}
-	other := Battlesnake{
-		Head: Coord{X: 5, Y: 8},
-		Body: []Coord{{X: 5, Y: 8},{X: 6, Y: 8}, {X: 6, Y: 7}, {X: 6, Y: 6}},
-		Health: 100,
-		ID: "other",
-	}
-	state := GameState{
-		Board: Board{
-			Snakes: []Battlesnake{me, other},
-			Height: 11,
-			Width:  11,
-			Food:   []Coord{{X: 3, Y: 10}},
-		},
-		Turn: 9999999,
-		You: me,
-	}
-	// Act 1000x (this isn't a great way to test, but it's okay for starting out)
 	for i := 0; i < 1000; i++ {
-		nextMove := move(state)
-		// Assert never move up
-		if nextMove.Move != "right" {
-			t.Errorf("Tail is not getting set as walkable, %s", nextMove.Move)
+		for i := 0; i < 1; i++ {	
+			// Arrange
+			me := Battlesnake{
+				Head: Coord{X: 4, Y: 4},
+				Body: []Coord{{X: 4, Y: 4}, {X: 4, Y: 5}, {X: 3, Y: 5}, {X: 3, Y: 4}, {X: 3, Y: 3}, {X: 4, Y: 3}, {X: 5, Y: 3}},
+				Health: 100,
+				ID: "me",
+			}
+			other := Battlesnake{
+				Head: Coord{X: 5, Y: 8},
+				Body: []Coord{{X: 5, Y: 8},{X: 6, Y: 8}, {X: 6, Y: 7}, {X: 6, Y: 6}},
+				Health: 100,
+				ID: "other",
+			}
+			state := GameState{
+				Board: Board{
+					Snakes: []Battlesnake{me, other},
+					Height: 11,
+					Width:  11,
+					Food:   []Coord{{X: 3, Y: 10}},
+				},
+				Turn: 0,
+				You: me,
+			}
+			nextMove := move(state)
+			// Assert never move up
+			if nextMove.Move != "right" {
+				t.Errorf("Tail is not getting set as walkable, %s", nextMove.Move)
+			}
+		}
+		for i := 0; i < 1; i++ {	
+			// Arrange
+			me := Battlesnake{
+				Head: Coord{X: 5, Y: 4},
+				Body: []Coord{{X: 5, Y: 4},{X: 4, Y: 4}, {X: 4, Y: 5}, {X: 3, Y: 5}, {X: 3, Y: 4}, {X: 3, Y: 3}, {X: 4, Y: 3}, {X: 5, Y: 3}},
+				Health: 20,
+				ID: "me",
+			}
+			other := Battlesnake{
+				Head: Coord{X: 5, Y: 8},
+				Body: []Coord{{X: 5, Y: 8},{X: 6, Y: 8}, {X: 6, Y: 7}, {X: 6, Y: 6}},
+				Health: 20,
+				ID: "other",
+			}
+			state := GameState{
+				Board: Board{
+					Snakes: []Battlesnake{me, other},
+					Height: 11,
+					Width:  11,
+					Food:   []Coord{{X: 3, Y: 10}},
+				},
+				Turn: 9999999,
+				You: me,
+			}
+			nextMove := move(state)
+			// Assert never move up
+			if nextMove.Move != "up" {
+				t.Errorf("Tail is not getting set as walkable, %s", nextMove.Move)
+			}
 		}
 	}
-}
-for i := 0; i < 1; i++ {	
-	// Arrange
-	me := Battlesnake{
-		Head: Coord{X: 5, Y: 4},
-		Body: []Coord{{X: 5, Y: 4},{X: 4, Y: 4}, {X: 4, Y: 5}, {X: 3, Y: 5}, {X: 3, Y: 4}, {X: 3, Y: 3}, {X: 4, Y: 3}, {X: 5, Y: 3}},
-		Health: 20,
-		ID: "me",
-	}
-	other := Battlesnake{
-		Head: Coord{X: 5, Y: 8},
-		Body: []Coord{{X: 5, Y: 8},{X: 6, Y: 8}, {X: 6, Y: 7}, {X: 6, Y: 6}},
-		Health: 20,
-		ID: "other",
-	}
-	state := GameState{
-		Board: Board{
-			Snakes: []Battlesnake{me, other},
-			Height: 11,
-			Width:  11,
-			Food:   []Coord{{X: 3, Y: 10}},
-		},
-		Turn: 9999999,
-		You: me,
-	}
-	// Act 1000x (this isn't a great way to test, but it's okay for starting out)
-	for i := 0; i < 1000; i++ {
-		nextMove := move(state)
-		// Assert never move up
-		if nextMove.Move != "up" {
-			t.Errorf("Tail is not getting set as walkable, %s", nextMove.Move)
-		}
-	}
-}
 }
 
 // Test that we don't set a tail next to a head as walkable.
 // Multi turn test to make sure we are setting snake tails as walkable correctly.
 func TestTailWalkable3(t *testing.T) {
-	for i := 0; i < 1; i++ {	
-		// Arrange
-		me := Battlesnake{
-			Head: Coord{X: 4, Y: 4},
-			Body: []Coord{{X: 4, Y: 4}, {X: 4, Y: 5}, {X: 5, Y: 5}},
-			Health: 100,
-			ID: "me",
-		}
-		other := Battlesnake{
-			Head: Coord{X: 5, Y: 3},
-			Body: []Coord{{X: 5, Y: 3},{X: 6, Y: 3}, {X: 6, Y: 4}, {X: 7, Y: 4}, {X: 7, Y: 3}, {X: 7, Y: 2}, {X: 6, Y: 2}, {X: 5, Y: 2}, {X: 4, Y: 2}, {X: 4, Y: 3}},
-			Health: 100,
-			ID: "other",
-		}
-		state := GameState{
-			Board: Board{
-				Snakes: []Battlesnake{me, other},
-				Height: 11,
-				Width:  11,
-				Food:   []Coord{{X: 3, Y: 10}},
-			},
-			Turn: 9999999,
-			You: me,
-		}
-		// Act 1000x (this isn't a great way to test, but it's okay for starting out)
-		for i := 0; i < 1000; i++ {
+	for i := 0; i < 1000; i++ {
+		for i := 0; i < 1; i++ {	
+			// Arrange
+			me := Battlesnake{
+				Head: Coord{X: 4, Y: 4},
+				Body: []Coord{{X: 4, Y: 4}, {X: 4, Y: 5}, {X: 5, Y: 5}},
+				Health: 100,
+				ID: "me",
+			}
+			other := Battlesnake{
+				Head: Coord{X: 5, Y: 3},
+				Body: []Coord{{X: 5, Y: 3},{X: 6, Y: 3}, {X: 6, Y: 4}, {X: 7, Y: 4}, {X: 7, Y: 3}, {X: 7, Y: 2}, {X: 6, Y: 2}, {X: 5, Y: 2}, {X: 4, Y: 2}, {X: 4, Y: 3}},
+				Health: 100,
+				ID: "other",
+			}
+			state := GameState{
+				Board: Board{
+					Snakes: []Battlesnake{me, other},
+					Height: 11,
+					Width:  11,
+					Food:   []Coord{{X: 3, Y: 10}},
+				},
+				Turn: 0,
+				You: me,
+			}
 			nextMove := move(state)
 			// Assert never move up
 			if nextMove.Move == "down" {
 				t.Errorf("Tail incorrectly set as walkable, %s", nextMove.Move)
 			}
 		}
-	}
-	for i := 0; i < 1; i++ {
-		// Arrange
-		me := Battlesnake{
-			Head: Coord{X: 4, Y: 4},
-			Body: []Coord{{X: 4, Y: 4}, {X: 4, Y: 5}, {X: 5, Y: 5}},
-			Health: 90,
-			ID: "me",
-		}
-		other := Battlesnake{
-			Head: Coord{X: 5, Y: 3},
-			Body: []Coord{{X: 5, Y: 3},{X: 6, Y: 3}, {X: 6, Y: 4}, {X: 7, Y: 4}, {X: 7, Y: 3}, {X: 7, Y: 2}, {X: 6, Y: 2}, {X: 5, Y: 2}, {X: 4, Y: 2}, {X: 4, Y: 3}},
-			Health: 90,
-			ID: "other",
-		}
-		state := GameState{
-			Board: Board{
-				Snakes: []Battlesnake{me, other},
-				Height: 11,
-				Width:  11,
-				Food:   []Coord{{X: 5, Y: 4}},
-			},
-			Turn: 9999999,
-			You: me,
-		}
-		// Act 1000x (this isn't a great way to test, but it's okay for starting out)
-		for i := 0; i < 1000; i++ {
+		for i := 0; i < 1; i++ {
+			// Arrange
+			me := Battlesnake{
+				Head: Coord{X: 4, Y: 4},
+				Body: []Coord{{X: 4, Y: 4}, {X: 4, Y: 5}, {X: 5, Y: 5}},
+				Health: 90,
+				ID: "me",
+			}
+			other := Battlesnake{
+				Head: Coord{X: 5, Y: 3},
+				Body: []Coord{{X: 5, Y: 3},{X: 6, Y: 3}, {X: 6, Y: 4}, {X: 7, Y: 4}, {X: 7, Y: 3}, {X: 7, Y: 2}, {X: 6, Y: 2}, {X: 5, Y: 2}, {X: 4, Y: 2}, {X: 4, Y: 3}},
+				Health: 90,
+				ID: "other",
+			}
+			state := GameState{
+				Board: Board{
+					Snakes: []Battlesnake{me, other},
+					Height: 11,
+					Width:  11,
+					Food:   []Coord{{X: 5, Y: 4}},
+				},
+				Turn: 9999999,
+				You: me,
+			}
 			nextMove := move(state)
 			// Assert never move up
 			if nextMove.Move == "down" {
@@ -770,3 +758,69 @@ func TestTailWalkable3(t *testing.T) {
 	}
 }
 
+// Test that we don't walk on a tail if snake eats twice in a row. 
+// Multi turn test to make sure we are setting snake tails as walkable correctly.
+func TestTailWalkable4(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		for i := 0; i < 1; i++ {	
+			// Arrange
+			me := Battlesnake{
+				Head: Coord{X: 7, Y: 1},
+				Body: []Coord{{X: 7, Y: 1}, {X: 6, Y: 1}, {X: 5, Y: 1}, {X: 4, Y: 1}, {X: 3, Y: 1}},
+				Health: 100,
+				ID: "me",
+			}
+			other := Battlesnake{
+				Head: Coord{X: 10, Y: 3},
+				Body: []Coord{{X: 10, Y: 3},{X: 9, Y: 3}, {X: 8, Y: 3}, {X: 7, Y: 3}, {X: 8, Y: 0}, {X: 8, Y: 1}, {X: 8, Y: 2}, {X: 7, Y: 2}},
+				Health: 100,
+				ID: "other",
+			}
+			state := GameState{
+				Board: Board{
+					Snakes: []Battlesnake{me, other},
+					Height: 11,
+					Width:  11,
+					Food:   []Coord{{X: 5, Y: 4}},
+				},
+				Turn: 0,
+				You: me,
+			}
+			nextMove := move(state)
+			// Assert never move up
+			if nextMove.Move != "down" {
+				t.Errorf("Tail incorrectly set as walkable, %s", nextMove.Move)
+			}
+		}
+		for i := 0; i < 1; i++ {	
+			// Arrange
+			me := Battlesnake{
+				Head: Coord{X: 7, Y: 1},
+				Body: []Coord{{X: 7, Y: 1}, {X: 6, Y: 1}, {X: 5, Y: 1}, {X: 4, Y: 1}, {X: 3, Y: 1}},
+				Health: 100,
+				ID: "me",
+			}
+			other := Battlesnake{
+				Head: Coord{X: 10, Y: 3},
+				Body: []Coord{{X: 10, Y: 3},{X: 9, Y: 3}, {X: 8, Y: 3}, {X: 7, Y: 3}, {X: 8, Y: 0}, {X: 8, Y: 1}, {X: 8, Y: 2}, {X: 7, Y: 2}},
+				Health: 100,
+				ID: "other",
+			}
+			state := GameState{
+				Board: Board{
+					Snakes: []Battlesnake{me, other},
+					Height: 11,
+					Width:  11,
+					Food:   []Coord{{X: 5, Y: 4}},
+				},
+				Turn: 9999999,
+				You: me,
+			}
+			nextMove := move(state)
+			// Assert never move up
+			if nextMove.Move != "down" {
+				t.Errorf("Tail incorrectly set as walkable, %s", nextMove.Move)
+			}
+		}
+	}
+}

--- a/snakes/go/pathy-snake/pathing.go
+++ b/snakes/go/pathy-snake/pathing.go
@@ -41,8 +41,7 @@ func addSnakesToGrid(state GameState, grid *Grid) {
 	}
 
 	// Clear any map that might exist between games.
-	// Note: 9999999 is used for testing purposes.
-	if state.Turn <= 3 || state.Turn == 9999999 {
+	if state.Turn <= 3 {
 		snakeHealths = make(map[string]int)
 		updateSnakeHealth(state)
 	}
@@ -345,7 +344,7 @@ var snakeHealths = make(map[string]int)
 func didSnakeEatFood(snake Battlesnake, state GameState) bool {
 	// If the snakes health is greater than the previous turn, they ate food.
 	var ate bool
-	if int(snake.Health) > snakeHealths[snake.ID] && state.Turn != 0 {
+	if int(snake.Health) >= snakeHealths[snake.ID] && state.Turn != 0 {
 		ate = true
 	} else {
 		ate = false


### PR DESCRIPTION
Noticed a bug in the new tail walking logic when watching back this game: https://play.battlesnake.com/g/06d75bf1-3c4c-49b4-899a-323d772e7034/

We were marking tails as walkable if a snake ate two turns in a row. That's a no no so I've fixed it. 

I also adjusted the multi turn tests. They were passing before but I think there were possibly false positives that could occur and that shouldn't happen anymore. 