### PR TITLE
Update defensive head logic

### DIFF
--- a/snakes/go/pathy-snake/logic_test.go
+++ b/snakes/go/pathy-snake/logic_test.go
@@ -266,6 +266,46 @@ func TestFoodEating6(t *testing.T) {
 		}
 	}
 }
+
+// Test that we go towards the closest food not next to large or equal size snake.
+func TestFoodEating7(t *testing.T) {
+	// Arrange
+	me := Battlesnake{
+		Head:   Coord{X: 1, Y: 0},
+		Body:   []Coord{{X: 1, Y: 0}, {X: 2, Y: 0}, {X: 3, Y: 0}},
+		Health: 20,
+		Length: 3,
+		ID:    "me",
+	}
+	other := Battlesnake{
+		Head: Coord{X: 10, Y: 0},
+		Body: []Coord{{X: 10, Y: 0}, {X: 10, Y: 1}, {X: 10, Y: 2}},
+		Length: 3,
+		ID:    "other",
+	}
+	state := GameState{
+		Board: Board{
+			Snakes: []Battlesnake{me, other},
+			Food:   []Coord{{X: 0, Y: 0}, {X: 2, Y: 7}},
+			Height: 11,
+			Width:  11,
+		},
+		You: me,
+		Game: Game{
+			Ruleset: Ruleset{
+				Name: "wrapped",
+			},
+		},
+	}
+	// Act 1000x (this isn't a great way to test, but it's okay for starting out)
+	for i := 0; i < 1000; i++ {
+		nextMove := move(state)
+		// Assert never move left
+		if nextMove.Move == "left" {
+			t.Errorf("snake moved to a food next to bigger snake, %s", nextMove.Move)
+		}
+	}
+}
 		
 // Test that we do not wrap around into our own body.
 func TestBodyWrap1(t *testing.T) {

--- a/snakes/go/pathy-snake/pathing.go
+++ b/snakes/go/pathy-snake/pathing.go
@@ -185,11 +185,11 @@ func getPath(state GameState, grid *Grid) *Path {
 					}
 				}
 			}
-		}
-		if len(walkableCells) > 0 {
-			targetCell = walkableCells[rand.Intn(len(walkableCells))]
-		} else {
-			log.Printf("No walkable cells in top half of board.\n")
+			if len(walkableCells) > 0 {
+				targetCell = walkableCells[rand.Intn(len(walkableCells))]
+			} else {
+				log.Printf("No walkable cells in top half of board.\n")
+			}
 		}
 	} else {
 		// Create a list of walkable cells in the bottom half of the board.

--- a/snakes/go/pathy-snake/pathing.go
+++ b/snakes/go/pathy-snake/pathing.go
@@ -185,11 +185,11 @@ func getPath(state GameState, grid *Grid) *Path {
 					}
 				}
 			}
-			if len(walkableCells) > 0 {
-				targetCell = walkableCells[rand.Intn(len(walkableCells))]
-			} else {
-				log.Printf("No walkable cells in top half of board.\n")
-			}
+		}
+		if len(walkableCells) > 0 {
+			targetCell = walkableCells[rand.Intn(len(walkableCells))]
+		} else {
+			log.Printf("No walkable cells in top half of board.\n")
 		}
 	} else {
 		// Create a list of walkable cells in the bottom half of the board.

--- a/snakes/go/pathy-snake/pathing.go
+++ b/snakes/go/pathy-snake/pathing.go
@@ -66,28 +66,28 @@ func addSnakesToGrid(state GameState, grid *Grid) {
 			if otherSnake.Head.X-1 >= 0 {
 				// If the snake is longer than us, then we want to avoid walking on cells next to their heads.
 				if otherSnake.Length >= state.You.Length {
-					grid.Get(otherSnake.Head.X-1, otherSnake.Head.Y).Walkable = false
+					grid.Get(otherSnake.Head.X-1, otherSnake.Head.Y).Cost = 1000
 				} else {
 					grid.Get(otherSnake.Head.X-1, otherSnake.Head.Y).Cost = 1.5
 				}
 			}
 			if otherSnake.Head.X+1 <= state.Board.Width-1 {
 				if otherSnake.Length >= state.You.Length {
-					grid.Get(otherSnake.Head.X+1, otherSnake.Head.Y).Walkable = false
+					grid.Get(otherSnake.Head.X+1, otherSnake.Head.Y).Cost = 1000
 				} else {
 					grid.Get(otherSnake.Head.X+1, otherSnake.Head.Y).Cost = 1.5
 				}
 			}
 			if otherSnake.Head.Y-1 >= 0 {
 				if otherSnake.Length >= state.You.Length {
-					grid.Get(otherSnake.Head.X, otherSnake.Head.Y-1).Walkable = false
+					grid.Get(otherSnake.Head.X, otherSnake.Head.Y-1).Cost = 1000
 				} else {
 					grid.Get(otherSnake.Head.X, otherSnake.Head.Y-1).Cost = 1.5
 				}
 			}
 			if otherSnake.Head.Y+1 <= state.Board.Height-1 {
 				if otherSnake.Length >= state.You.Length {
-					grid.Get(otherSnake.Head.X, otherSnake.Head.Y+1).Walkable = false
+					grid.Get(otherSnake.Head.X, otherSnake.Head.Y+1).Cost = 1000
 				} else {
 					grid.Get(otherSnake.Head.X, otherSnake.Head.Y+1).Cost = 1.5
 				}
@@ -218,6 +218,11 @@ func getPath(state GameState, grid *Grid) *Path {
 		// Iterate over all the food in the game state.
 		var targetFoodCell []*Cell
 		for _, food := range state.Board.Food {
+			// Since a cell next to a larger snakes head is walkable it is possible we may find a food in that cell. 
+			// We want to avoid a piece of food that is next to a snakes head if that snake is larger.
+			if isNextToLarger(food.X, food.Y, state) || isSurrounded(food.X, food.Y, state) {
+				continue
+			}
 			// Continue if food not walkable.
 			if !grid.Get(food.X, food.Y).Walkable {
 				continue


### PR DESCRIPTION
This PR makes cells next to a larger snakes head walkable again however it makes them very costly. This should account for the scenarios where Pathy gets locked into no moves because it is surrounded by snakes. Instead now when that occurs it will still be able to find a path instead of timing out and defaulting to the last move. 