### PR TITLE
Fix broken output on simulation comments

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -39,7 +39,7 @@ jobs:
           content="${content//'%'/'%25'}"
           content="${content//$'\n'/'%0A'}"
           content="${content//$'\r'/'%0D'}"
-          echo "::set-output name=result::$content"
+          echo "::set-output name=result::$(cat simulate_royale.log)"
       
     # Use the output from the simulate-games step
     - name: Get the simulate-games output


### PR DESCRIPTION
Trying different things from https://github.community/t/set-output-truncates-multiline-strings/16852/11 -- prior workaround seems to have stopped working.