### PR TITLE
Cleanup some of our actions

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -14,7 +14,7 @@ permissions:
   packages: write
 
 jobs:
-  deploy:
+  deployment:
     if: ${{ github.event.issue.pull_request }} # only run on pull request comments
     runs-on: ubuntu-latest
     environment: production-secrets

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -14,7 +14,7 @@ permissions:
   packages: write
 
 jobs:
-  demo:
+  deploy:
     if: ${{ github.event.issue.pull_request }} # only run on pull request comments
     runs-on: ubuntu-latest
     environment: production
@@ -36,14 +36,14 @@ jobs:
       # conditionally run a noop deployment
       - name: fake noop deploy
         if: ${{ steps.branch-deploy.outputs.continue == 'true' && steps.branch-deploy.outputs.noop == 'true' }}
-        run: echo "We do not currently have a noop deploy configured. A proper noop deploy may be added in the future. "
+        run: |
+          echo "We do not currently have a noop deploy configured. A proper noop deploy may be added in the future."
+          echo "DEPLOY_MESSAGE=We do not currently have a noop deploy configured. A proper noop deploy may be added in the future." >> $GITHUB_ENV
 
       # Production deploy logic
       - name: fake regular deploy
         if: ${{ steps.branch-deploy.outputs.continue == 'true' && steps.branch-deploy.outputs.noop != 'true' }}
-        run: |
-          echo "I am doing a fake regular deploy"
-          git branch
+        run: echo "I am doing a production deploy"
 
       - name: Get changed files
         if: ${{ steps.branch-deploy.outputs.continue == 'true' && steps.branch-deploy.outputs.noop != 'true' }}
@@ -52,9 +52,7 @@ jobs:
 
       - name: Build the Docker image
         if: ${{ steps.branch-deploy.outputs.continue == 'true' && steps.branch-deploy.outputs.noop != 'true' }}
-        run: |
-          git branch
-          docker build . --file Dockerfile --tag ghcr.io/es-na-battlesnake/code-snake:${{ github.sha }}
+        run: docker build . --file Dockerfile --tag ghcr.io/es-na-battlesnake/code-snake:${{ github.sha }}
 
       - name: Login to GitHub Container Registry
         if: ${{ steps.branch-deploy.outputs.continue == 'true' && steps.branch-deploy.outputs.noop != 'true' }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,8 +4,6 @@ permissions:
   packages: write
 
 on:
-  push:
-    branches: [ main ]
   workflow_dispatch:
     inputs:
       delete:

--- a/.github/workflows/simulate-games.yml
+++ b/.github/workflows/simulate-games.yml
@@ -2,9 +2,16 @@ name: Simulate Snake Games
 
 on:
   push:
-    branches: [ main ]
+    branches-ignore:
+      - main
+    paths:
+      - 'snakes/**'
+  # trigger action on new pull request pushes
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+    paths:
+      - 'snakes/**'
 
 jobs:
 


### PR DESCRIPTION
### deploy-branch

- Output custom message if someone attempts to run `.deploy noop`
- Don't need to log `git branch` anymore
- Change name from `demo` to `deploy`

### docker-img

- Switch to run on `workflow_dispatch` only. With Branch Deploy we no longer need to deploy when PR's are merged to main. Left the manual approach for now incase anything comes up with branch deploys. 

### simulate-games

- only run when a push happens a branch that targets main and includes changes to files in the `snakes` directory. 