### PR TITLE
Add deploy and codeql badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# ES NA Battlesnakes
+# ES NA Battlesnakes ![Deploy](https://github.com/es-na-battlesnake/snakes/actions/workflows/deploy-branch.yml/badge.svg) ![CodeQL](https://github.com/es-na-battlesnake/snakes/actions/workflows/codeql-analysis.yml/badge.svg)
 
 [Battlesnakes](https://play.battlesnake.com/) created by a [small team](https://play.battlesnake.com/t/es-na/) of GitHub Enterprise Support Engineers as a learning and team-building exercise.
-
-![Deploy](https://github.com/es-na-battlesnake/snakes/actions/workflows/deploy-branch.yml/badge.svg) ![CodeQL](https://github.com/es-na-battlesnake/snakes/actions/workflows/codeql-analysis.yml/badge.svg)
 
 ## Adding snakes
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [Battlesnakes](https://play.battlesnake.com/) created by a [small team](https://play.battlesnake.com/t/es-na/) of GitHub Enterprise Support Engineers as a learning and team-building exercise.
 
+![Deploy](https://github.com/es-na-battlesnake/snakes/actions/workflows/deploy-branch.yml/badge.svg) ![CodeQL](https://github.com/es-na-battlesnake/snakes/actions/workflows/codeql-analysis.yml/badge.svg)
+
 ## Adding snakes
 
 1. Add snake directory within `snakes`


### PR DESCRIPTION
Adds a badge to the readme for deployments and codeql

Rendered:

<img width="1441" alt="Screen Shot 2022-09-22 at 11 22 01 AM" src="https://user-images.githubusercontent.com/17680929/191822856-6dc757c7-2698-4c03-a158-a71940a002c5.png">