### PR TITLE
Add to jobs to noop deployment for changed files

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -52,6 +52,25 @@ jobs:
         run: |
           echo "Changed files: ${{ steps.changed-files.outputs.all }}"
           echo "DEPLOY_MESSAGE=Changed files: ${{ steps.changed-files.outputs.all }}" >> $GITHUB_ENV
+
+      # Check if changed files are in the full deployment path
+      - name: Check if changed files are in the deployable path
+        if: ${{ steps.branch-deploy.outputs.continue == 'true' && steps.branch-deploy.outputs.noop == 'true' }}
+        id: check-path
+        run: |
+         # if changing README.md then no full production deploy will be triggered
+          if [[ ${{ steps.changed-files.outputs.all }} == *"README.md"* ]]; then
+            echo "DEPLOY_MESSAGE=No full production deploy will take place. Only README.md was changed." >> $GITHUB_ENV
+            echo "::set-output name=continue::false"
+          else
+            echo "::set-output name=continue::true"
+          fi
+      
+      - name: Prod deploy required?
+        if: ${{ steps.branch-deploy.outputs.continue == 'true' && steps.branch-deploy.outputs.noop == 'true' && steps.check-path.outputs.continue == 'true' }}
+        run: |
+          echo "A full production deployment would be triggered here."
+          echo "DEPLOY_MESSAGE=A full production deployment would be triggered here." >> $GITHUB_ENV
     
       # Production deploy logic
       - name: fake regular deploy

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -39,7 +39,20 @@ jobs:
         run: |
           echo "We do not currently have a noop deploy configured. A proper noop deploy may be added in the future."
           echo "DEPLOY_MESSAGE=We do not currently have a noop deploy configured. A proper noop deploy may be added in the future." >> $GITHUB_ENV
+      
+      # Get changed file names for noop deploy message
+      - name: Get changed files
+        if: ${{ steps.branch-deploy.outputs.continue == 'true' && steps.branch-deploy.outputs.noop == 'true' }}
+        id: changed-files
+        uses: tj-actions/changed-files@v29.0.7
 
+      # Output changed files as part of the deployment message
+      - name: Output changed files
+        if: ${{ steps.branch-deploy.outputs.continue == 'true' && steps.branch-deploy.outputs.noop == 'true' }}
+        run: |
+          echo "Changed files: ${{ steps.changed-files.outputs.all }}"
+          echo "DEPLOY_MESSAGE=Changed files: ${{ steps.changed-files.outputs.all }}" >> $GITHUB_ENV
+    
       # Production deploy logic
       - name: fake regular deploy
         if: ${{ steps.branch-deploy.outputs.continue == 'true' && steps.branch-deploy.outputs.noop != 'true' }}


### PR DESCRIPTION
Adds some noop deploy logic that checks to see if a full production deployment will be required. Right now it will just look to see if the changed file is the readme file. 

If changing just the readme then we don't need to full prod deploy. 

If changing something else then we should full prod deploy. 

If this works as expected I'll follow up with another PR that adds the conditional logic to the prod deployment path. 

The main goal is to speed up deployments where possible. 