### PR TITLE
only run flask debug inside a codespace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:3.1.2
 EXPOSE 4567
 CMD ["/usr/bin/supervisord"]
 
-RUN apt-get update && apt-get install --no-install-suggests -y supervisor=4.2.2-2 && apt-get install pip=20.3.4-4 jq=1.6-2.1 -y
+RUN apt-get update && apt-get install --no-install-suggests -y supervisor=4.2.2-2 && apt-get install python3-pip=20.3.4-4+deb11u1 jq=1.6-2.1 -y
 RUN mkdir -p /var/log/supervisor
 
 RUN bundle config --global frozen 1 && bundle config set --local without 'dev'

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:3.1.2
 EXPOSE 4567
 CMD ["/usr/bin/supervisord"]
 
-RUN apt-get update && apt-get install --no-install-suggests -y supervisor=4.2.2-2 && apt-get install pip jq=1.6-2.1 -y
+RUN apt-get update && apt-get install --no-install-suggests -y supervisor=4.2.2-2 && apt-get install pip=20.3.4-4+deb11u1 jq=1.6-2.1 -y
 RUN mkdir -p /var/log/supervisor
 
 RUN bundle config --global frozen 1 && bundle config set --local without 'dev'

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:3.1.2
 EXPOSE 4567
 CMD ["/usr/bin/supervisord"]
 
-RUN apt-get update && apt-get install --no-install-suggests -y supervisor=4.2.2-2 && apt-get install pip=20.3.4-4+deb11u1 jq=1.6-2.1 -y
+RUN apt-get update && apt-get install --no-install-suggests -y supervisor=4.2.2-2 && apt-get install pip=20.3.4-4 jq=1.6-2.1 -y
 RUN mkdir -p /var/log/supervisor
 
 RUN bundle config --global frozen 1 && bundle config set --local without 'dev'

--- a/snakes/python/starter-snake/src/main.py
+++ b/snakes/python/starter-snake/src/main.py
@@ -73,9 +73,4 @@ if __name__ == "__main__":
 
     print(f"\nRunning Battlesnake server at http://{host}:{port}")
     app.env = 'development'
-
-    # Only run Flask in debug when inside a codespace
-    if os.environ.get('CODESPACES') == 'true':
-        app.run(host=host, port=port, debug=True)
-    else:
-        app.run(host=host, port=port)
+    app.run(host=host, port=port)

--- a/snakes/python/starter-snake/src/main.py
+++ b/snakes/python/starter-snake/src/main.py
@@ -73,4 +73,9 @@ if __name__ == "__main__":
 
     print(f"\nRunning Battlesnake server at http://{host}:{port}")
     app.env = 'development'
-    app.run(host=host, port=port, debug=True)
+
+    # Only run Flask in debug when inside a codespace
+    if os.environ.get('CODESPACES') == 'true':
+        app.run(host=host, port=port, debug=True)
+    else:
+        app.run(host=host, port=port)

--- a/snakes/python/summer-league-2022/src/main.py
+++ b/snakes/python/summer-league-2022/src/main.py
@@ -73,9 +73,4 @@ if __name__ == "__main__":
 
     print(f"\nRunning Battlesnake server at http://{host}:{port}")
     app.env = 'development'
-    
-    # Only run Flask in debug when inside a codespace
-    if os.environ.get('CODESPACES') == 'true':
-        app.run(host=host, port=port, debug=True)
-    else:
-        app.run(host=host, port=port)
+    app.run(host=host, port=port)

--- a/snakes/python/summer-league-2022/src/main.py
+++ b/snakes/python/summer-league-2022/src/main.py
@@ -73,4 +73,9 @@ if __name__ == "__main__":
 
     print(f"\nRunning Battlesnake server at http://{host}:{port}")
     app.env = 'development'
-    app.run(host=host, port=port, debug=True)
+    
+    # Only run Flask in debug when inside a codespace
+    if os.environ.get('CODESPACES') == 'true':
+        app.run(host=host, port=port, debug=True)
+    else:
+        app.run(host=host, port=port)


### PR DESCRIPTION
Address security concern that arises when flask is running in debug mode in production. 

Just going to disable debug mode all together and if it is needed someone can turn it on in dev. 