### PR TITLE
Update Dockerfile.base

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -3,7 +3,7 @@ FROM ruby:3.2.2
 EXPOSE 4567
 CMD ["/usr/bin/supervisord"]
 
-RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y supervisor=4.2.2-2 && apt-get install python3-pip=20.3.4-4+deb11u1 jq=1.6-2.1 -y
+RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y supervisor=4.2.5-1 && apt-get install jq=1.6-2.1 -y
 RUN mkdir -p /var/log/supervisor
 
 RUN bundle config --global frozen 1 && bundle config set --local without 'dev'
@@ -15,7 +15,5 @@ WORKDIR /usr/src/app
 
 COPY Gemfile Gemfile.lock ./
 RUN bundle install
-
-RUN pip install --no-cache-dir flask==2.2.2 pathfinding==1.0.1
 
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
The docker base image has been failing to build as it could not locate `supervisor=4.2.2-2`.  https://github.com/es-na-battlesnake/snakes/actions/runs/5545706480/jobs/10125001196

This is a result of [ruby:3.2.2 "latest"](https://hub.docker.com/layers/library/ruby/latest/images/sha256-669a9f71cf3b339ad85ba8d4a5efe7511cd57f59f5c2fd492970e683608a8d8b?context=explore) now being on bookworm which results in a newer version of the [Supervisor package](https://packages.debian.org/bookworm/supervisor). 

This PR updates the supervisor package. I've also decided to remove the python components from the base image for now as it appears bookworm might be a little more strict about running duplicate package managers `apt` and `pip`. We also don't have any current python snakes running. I can look at adding python back in a separate PR. 