### PR TITLE
Actually chose a random cell and cost changes

### DIFF
--- a/snakes/go/pathy-snake/helpers.go
+++ b/snakes/go/pathy-snake/helpers.go
@@ -84,8 +84,19 @@ func chooseTargetCell(walkableCells []*Cell) *Cell {
 
 // function to choose a random target cell that is walkable
 func chooseRandomWalkableTargetCell(grid *Grid, state GameState) *Cell {
-	// Iterate over all the cells in the grid.
-	for _, cell := range grid.CellsByWalkable(true) {
+	// randomize the order of the walkable cells so we don't always choose the same one.
+	walkableCells := grid.CellsByWalkable(true)
+	rand.Shuffle(len(walkableCells), func(i, j int) { walkableCells[i], walkableCells[j] = walkableCells[j], walkableCells[i] })
+
+	// Iterate over all the walkableCells.
+	for _, cell := range walkableCells {
+		// Make sure there is a path to the cell we chose.
+		path := grid.GetPathFromCells(grid.Get(state.You.Head.X, state.You.Head.Y), grid.Get(cell.X, cell.Y), false, false, state.isWrapped())
+
+		if path.Length() == 0 {
+			continue
+		}
+
 		// Set the target cell to be the first walkable cell that is not our head.
 		if cell.X != state.You.Head.X && cell.Y != state.You.Head.Y {
 			return cell

--- a/snakes/go/pathy-snake/pathing.go
+++ b/snakes/go/pathy-snake/pathing.go
@@ -54,17 +54,17 @@ func addSnakesToGrid(state GameState, grid *Grid) {
 			above := otherSnake.Head.cellAbove(state)
 			below := otherSnake.Head.cellBelow(state)
 			if otherSnake.isLargerThanUs(state) {
-				grid.Get(left.X, left.Y).Walkable = false
-				grid.Get(right.X, right.Y).Walkable = false
-				grid.Get(above.X, above.Y).Walkable = false
-				grid.Get(below.X, below.Y).Walkable = false
+				grid.Get(left.X, left.Y).Cost = 5
+				grid.Get(right.X, right.Y).Cost = 5
+				grid.Get(above.X, above.Y).Cost = 5
+				grid.Get(below.X, below.Y).Cost = 5
 				continue
 			}
 			// If the other snake is smaller than us, we want to make the cells next to their head walkable.
-			grid.Get(left.X, left.Y).Cost = 1.5
-			grid.Get(right.X, right.Y).Cost = 1.5
-			grid.Get(above.X, above.Y).Cost = 1.5
-			grid.Get(below.X, below.Y).Cost = 1.5
+			grid.Get(left.X, left.Y).Cost = 1
+			grid.Get(right.X, right.Y).Cost = 1
+			grid.Get(above.X, above.Y).Cost = 1
+			grid.Get(below.X, below.Y).Cost = 1
 		}
 	}
 	// Make sure our own head is walkable. We need to do this because the getPath function
@@ -125,10 +125,10 @@ func getTargetCell(state GameState, grid *Grid) *Cell {
 		targetCell = chooseNearestFood(grid, state)
 	}
 
-	// If targetCell is nil, then move in a direction that is further away from the larger snakes.
-	if targetCell == nil {
-		targetCell = moveAwayFromLargerSnakes(grid, state)
-	}
+	// // If targetCell is nil, then move in a direction that is further away from the larger snakes.
+	// if targetCell == nil {
+	// 	targetCell = moveAwayFromLargerSnakes(grid, state)
+	// }
 
 	// If we still don't have a target cell, then just pick a random walkable cell.
 	if targetCell == nil {


### PR DESCRIPTION
This PR makes sure that Pathy actually choses a random cell. Previously Pathy would favor 0,0 as it was first in the list most often. This updates that logic to get all walkable cells then randomize them before looping through them. I also make sure that we also chose a walkable cell and set it as the target only if we have a path to it. 

I also make some small tweaks to the cost of certain cells. Most notably the changing the cells next to a larger snake head to be walkable. 

Also removed the logic that moves away from larger snakes for now. 